### PR TITLE
fix: remove unused timbre require

### DIFF
--- a/src/com/nivekuil/nexus.clj
+++ b/src/com/nivekuil/nexus.clj
@@ -10,7 +10,6 @@
             [clojure.set :as set]
             [com.nivekuil.nexus :as nx]
             [clojure.string :as str]
-            [taoensso.timbre :as log]
             [clojure.data]
             [promesa.core :as p]))
 


### PR DESCRIPTION
Fixes an issue where nexus would crash if a project didn't have timbre. As far as I can tell it isn't used (probably an artifact from before logging was swapable).